### PR TITLE
winsock : hinst "family unspec" lead to "error 10061" in client code example !

### DIFF
--- a/desktop-src/WinSock/creating-a-socket-for-the-client.md
+++ b/desktop-src/WinSock/creating-a-socket-for-the-client.md
@@ -19,7 +19,7 @@ After initialization, a **SOCKET** object must be instantiated for use by the cl
                     hints;
 
     ZeroMemory( &hints, sizeof(hints) );
-    hints.ai_family = AF_UNSPEC;
+    hints.ai_family   = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
     ```


### PR DESCRIPTION

in server code example there's 
hints.ai_family = AF_INET;

and

in the client code example there's  
hints.ai_family = AF_UNSPEC;

that "family unspecific" in the example lead to "error 10061" .

i spend more than 2h trying to find where is the problem , and that "different family type" between the server and client examples was the problem .

so i suggest to change the client from "AF_UNSPEC" to "AF_INET" .